### PR TITLE
[No Ticket] Removed ENTITY_NAME constant in db entities

### DIFF
--- a/data/src/main/java/hera/database/DAO.java
+++ b/data/src/main/java/hera/database/DAO.java
@@ -15,12 +15,9 @@ public class DAO<T extends PersistenceEntity> {
 
 	private Class<T> cl;
 
-	private String entityName;
-
-	public DAO(Class<T> cl, String entityName) {
+	public DAO(Class<T> cl) {
 		this.cl = cl;
-		this.entityName = entityName;
-		LOG.debug("DAO for entity {} created", cl.getName());
+		LOG.debug("DAO for entity {} created", cl.getSimpleName());
 	}
 
 	public List<T> getAll() {
@@ -28,7 +25,7 @@ public class DAO<T extends PersistenceEntity> {
 		entityManager.getTransaction().begin();
 
 		try {
-			Query query = entityManager.createQuery("SELECT e FROM " + entityName + " e");
+			Query query = entityManager.createQuery("SELECT e FROM " + cl.getSimpleName() + " e");
 
 			@SuppressWarnings("unchecked")
 			List<T> results = query.getResultList();
@@ -57,7 +54,7 @@ public class DAO<T extends PersistenceEntity> {
 		EntityManager entityManager = JPAUtil.getEntityManager();
 		entityManager.getTransaction().begin();
 
-		StringBuilder queryString = new StringBuilder("SELECT e FROM " + entityName + " e WHERE ");
+		StringBuilder queryString = new StringBuilder("SELECT e FROM " + cl.getSimpleName() + " e WHERE ");
 
 		int i = 0;
 		String[] wheres = new String[whereClauses.size()];
@@ -102,7 +99,7 @@ public class DAO<T extends PersistenceEntity> {
 			entityManager.persist(object);
 
 			// only log if its not about metrics, else we would just spam our logs
-			if (!cl.getName().equals(Metric.class.getName())) LOG.info("Persisted entity of type {}", object.getClass().getName());
+			if (!cl.getName().equals(Metric.class.getName())) LOG.info("Persisted entity of type {}", object.getClass().getSimpleName());
 
 			return object;
 		} finally {
@@ -119,9 +116,9 @@ public class DAO<T extends PersistenceEntity> {
 			T entity = entityManager.find(cl, id);
 			if (entity != null) {
 				entityManager.remove(entity);
-				LOG.info("Deleted entity of type {}", cl.getName());
+				LOG.info("Deleted entity of type {}", cl.getSimpleName());
 			} else {
-				LOG.error("No entity found for type {}", cl.getName());
+				LOG.error("No entity found for type {}", cl.getSimpleName());
 			}
 		} finally {
 			entityManager.getTransaction().commit();
@@ -135,7 +132,7 @@ public class DAO<T extends PersistenceEntity> {
 
 		try {
 			entityManager.remove(entity);
-			LOG.info("Deleted entity of type {}", entity.getClass().getName());
+			LOG.info("Deleted entity of type {}", entity.getClass().getSimpleName());
 		} finally {
 			entityManager.getTransaction().commit();
 			entityManager.close();
@@ -148,7 +145,7 @@ public class DAO<T extends PersistenceEntity> {
 
 		try {
 			entityManager.merge(entity);
-			LOG.info("Merged entity of type {}", entity.getClass().getName());
+			LOG.info("Merged entity of type {}", entity.getClass().getSimpleName());
 		} finally {
 			entityManager.getTransaction().commit();
 			entityManager.close();
@@ -166,10 +163,10 @@ public class DAO<T extends PersistenceEntity> {
 
 			if (persistedEntity != null) {
 				entityManager.merge(entity);
-				LOG.info("Merged entity of type {}", entity.getClass().getName());
+				LOG.info("Merged entity of type {}", entity.getClass().getSimpleName());
 			} else {
 				entityManager.persist(entity);
-				LOG.info("Persisted entity of type {}", entity.getClass().getName());
+				LOG.info("Persisted entity of type {}", entity.getClass().getSimpleName());
 			}
 
 		} finally {

--- a/data/src/main/java/hera/database/entities/Alias.kt
+++ b/data/src/main/java/hera/database/entities/Alias.kt
@@ -19,8 +19,4 @@ data class Alias(
 		var guild: Long? = null
 ) : PersistenceEntity {
 	constructor(command: Command, alias: String, guild: Long?) : this(null, command, alias, guild)
-
-	companion object {
-		const val ENTITY_NAME = "Alias"
-	}
 }

--- a/data/src/main/java/hera/database/entities/Binding.kt
+++ b/data/src/main/java/hera/database/entities/Binding.kt
@@ -21,8 +21,4 @@ data class Binding(
 		var channelSnowflake: Long? = null
 ) : PersistenceEntity {
 	constructor(guild: Long, bindingType: BindingType, channelSnowflake: Long) : this(null, guild, bindingType, channelSnowflake)
-
-	companion object {
-		const val ENTITY_NAME = "Binding"
-	}
 }

--- a/data/src/main/java/hera/database/entities/Command.kt
+++ b/data/src/main/java/hera/database/entities/Command.kt
@@ -23,8 +23,4 @@ data class Command(
 		var level: Int? = null
 ) : PersistenceEntity {
 	constructor(name: CommandName, description: String, paramCount: Int, optionalParams: Int, level: Int) : this(null, name, description, paramCount, optionalParams, level)
-
-	companion object {
-		const val ENTITY_NAME = "Command"
-	}
 }

--- a/data/src/main/java/hera/database/entities/DefaultRole.kt
+++ b/data/src/main/java/hera/database/entities/DefaultRole.kt
@@ -17,8 +17,4 @@ data class DefaultRole(
 		var role: Role? = null
 ) : PersistenceEntity {
 	constructor(guild: Long, role: Role) : this(null, guild, role)
-
-	companion object {
-		const val ENTITY_NAME = "DefaultRole"
-	}
 }

--- a/data/src/main/java/hera/database/entities/GlobalSetting.kt
+++ b/data/src/main/java/hera/database/entities/GlobalSetting.kt
@@ -18,8 +18,4 @@ data class GlobalSetting(
 		var value: String? = null
 ) : PersistenceEntity {
 	constructor(key: GlobalSettingKey, value: String) : this(null, key, value)
-
-	companion object {
-		const val ENTITY_NAME = "GlobalSetting"
-	}
 }

--- a/data/src/main/java/hera/database/entities/Guild.kt
+++ b/data/src/main/java/hera/database/entities/Guild.kt
@@ -6,8 +6,4 @@ import javax.persistence.Table
 
 @Entity
 @Table(name = "guild")
-data class Guild(@Id override var id: Long? = null) : PersistenceEntity {
-	companion object {
-		const val ENTITY_NAME = "Guild"
-	}
-}
+data class Guild(@Id override var id: Long? = null) : PersistenceEntity

--- a/data/src/main/java/hera/database/entities/GuildSetting.kt
+++ b/data/src/main/java/hera/database/entities/GuildSetting.kt
@@ -21,8 +21,4 @@ data class GuildSetting(
 		var value: String? = null
 ) : PersistenceEntity {
 	constructor(guild: Long, key: GuildSettingKey, value: String) : this(null, guild, key, value)
-
-	companion object {
-		const val ENTITY_NAME = "GuildSetting"
-	}
 }

--- a/data/src/main/java/hera/database/entities/Localisation.kt
+++ b/data/src/main/java/hera/database/entities/Localisation.kt
@@ -20,8 +20,4 @@ data class Localisation(
 		var value: String? = null
 ) : PersistenceEntity {
 	constructor(language: String, key: LocalisationKey, value: String) : this(null, language, key, value)
-
-	companion object {
-		const val ENTITY_NAME = "Localisation"
-	}
 }

--- a/data/src/main/java/hera/database/entities/Metric.kt
+++ b/data/src/main/java/hera/database/entities/Metric.kt
@@ -33,8 +33,4 @@ data class Metric(
 		var details: String? = null
 ) : PersistenceEntity {
 	constructor(key: MetricKey, date: Timestamp, command: Command?, guild: Long, user: Long, value: Long?, details: String?) : this(null, key, date, command, guild, user, value, details)
-
-	companion object {
-		const val ENTITY_NAME = "Metric"
-	}
 }

--- a/data/src/main/java/hera/database/entities/ModuleSettings.kt
+++ b/data/src/main/java/hera/database/entities/ModuleSettings.kt
@@ -23,8 +23,4 @@ data class ModuleSettings(
 		var role: Role? = null
 ) : PersistenceEntity {
 	constructor(guild: Long, command: Command, enabled: Boolean, role: Role?) : this(null, guild, command, enabled, role)
-
-	companion object {
-		const val ENTITY_NAME = "ModuleSettings"
-	}
 }

--- a/data/src/main/java/hera/database/entities/Owner.kt
+++ b/data/src/main/java/hera/database/entities/Owner.kt
@@ -6,8 +6,4 @@ import javax.persistence.Table
 
 @Entity
 @Table(name = "owner")
-data class Owner(@Id override var id: Long? = null) : PersistenceEntity {
-	companion object {
-		const val ENTITY_NAME = "Owner"
-	}
-}
+data class Owner(@Id override var id: Long? = null) : PersistenceEntity

--- a/data/src/main/java/hera/database/entities/Role.kt
+++ b/data/src/main/java/hera/database/entities/Role.kt
@@ -21,8 +21,4 @@ data class Role(
 		var description: String? = null
 ) : PersistenceEntity {
 	constructor(guild: Long, parent: Role?, name: String, description: String) : this(null, guild, parent, name, description)
-
-	companion object {
-		const val ENTITY_NAME = "Role"
-	}
 }

--- a/data/src/main/java/hera/database/entities/RoleMember.kt
+++ b/data/src/main/java/hera/database/entities/RoleMember.kt
@@ -22,8 +22,4 @@ data class RoleMember(
 		var snowflakeType: SnowflakeType? = null
 ) : PersistenceEntity {
 	constructor(snowflake: Long, role: Role, snowflakeType: SnowflakeType) : this(null, snowflake, role, snowflakeType)
-
-	companion object {
-		const val ENTITY_NAME = "RoleMember"
-	}
 }

--- a/data/src/main/java/hera/database/entities/Token.kt
+++ b/data/src/main/java/hera/database/entities/Token.kt
@@ -20,8 +20,4 @@ data class Token(
 		var description: String? = null
 ) : PersistenceEntity {
 	constructor(token: String, key: TokenKey, description: String) : this(null, token, key, description)
-
-	companion object {
-		const val ENTITY_NAME = "Token"
-	}
 }

--- a/data/src/main/java/hera/database/entities/User.kt
+++ b/data/src/main/java/hera/database/entities/User.kt
@@ -6,8 +6,4 @@ import javax.persistence.Table
 
 @Entity
 @Table(name = "user")
-data class User(@Id override var id: Long? = null): PersistenceEntity {
-	companion object {
-		const val ENTITY_NAME = "User"
-	}
-}
+data class User(@Id override var id: Long? = null): PersistenceEntity

--- a/data/src/main/java/hera/store/DataStore.java
+++ b/data/src/main/java/hera/store/DataStore.java
@@ -60,10 +60,10 @@ public class DataStore {
 		roleMembers = new RoleMemberAccessUnit();
 		roles = new RoleAccessUnit();
 		tokens = new TokenAccessUnit();
-		guilds = new StorageAccessUnit<>(Guild.class, Guild.ENTITY_NAME);
-		owners = new StorageAccessUnit<>(Owner.class, Owner.ENTITY_NAME);
-		metrics = new StorageAccessUnit<>(Metric.class, Metric.ENTITY_NAME);
-		users = new StorageAccessUnit<>(User.class, User.ENTITY_NAME);
+		guilds = new StorageAccessUnit<>(Guild.class);
+		owners = new StorageAccessUnit<>(Owner.class);
+		metrics = new StorageAccessUnit<>(Metric.class);
+		users = new StorageAccessUnit<>(User.class);
 		LOG.info("DataStore initialised");
 	}
 

--- a/data/src/main/java/hera/store/unit/AliasAccessUnit.java
+++ b/data/src/main/java/hera/store/unit/AliasAccessUnit.java
@@ -10,7 +10,7 @@ import java.util.List;
 public class AliasAccessUnit extends StorageAccessUnit<Alias>{
 
 	public AliasAccessUnit() {
-		super(Alias.class, Alias.ENTITY_NAME);
+		super(Alias.class);
 	}
 
 	public List<Alias> forGuild(Long guild) {

--- a/data/src/main/java/hera/store/unit/BindingAccessUnit.java
+++ b/data/src/main/java/hera/store/unit/BindingAccessUnit.java
@@ -10,7 +10,7 @@ import java.util.List;
 public class BindingAccessUnit extends StorageAccessUnit<Binding>{
 
 	public BindingAccessUnit() {
-		super(Binding.class, Binding.ENTITY_NAME);
+		super(Binding.class);
 	}
 
 	public List<Binding> forGuild(Long guild) {

--- a/data/src/main/java/hera/store/unit/CommandAccessUnit.java
+++ b/data/src/main/java/hera/store/unit/CommandAccessUnit.java
@@ -11,7 +11,7 @@ import java.util.stream.Collectors;
 public class CommandAccessUnit extends StorageAccessUnit<Command> {
 
 	public CommandAccessUnit() {
-		super(Command.class, Command.ENTITY_NAME);
+		super(Command.class);
 	}
 
 	public List<Command> forName(CommandName name) {

--- a/data/src/main/java/hera/store/unit/DefaultRoleAccessUnit.java
+++ b/data/src/main/java/hera/store/unit/DefaultRoleAccessUnit.java
@@ -9,7 +9,7 @@ import java.util.List;
 public class DefaultRoleAccessUnit extends StorageAccessUnit<DefaultRole>{
 
 	public DefaultRoleAccessUnit() {
-		super(DefaultRole.class, DefaultRole.ENTITY_NAME);
+		super(DefaultRole.class);
 	}
 
 	public List<DefaultRole> forGuild(Long guild) {

--- a/data/src/main/java/hera/store/unit/GlobalSettingAccessUnit.java
+++ b/data/src/main/java/hera/store/unit/GlobalSettingAccessUnit.java
@@ -9,7 +9,7 @@ import java.util.List;
 public class GlobalSettingAccessUnit extends StorageAccessUnit<GlobalSetting>{
 
 	public GlobalSettingAccessUnit() {
-		super(GlobalSetting.class, GlobalSetting.ENTITY_NAME);
+		super(GlobalSetting.class);
 	}
 
 	public List<GlobalSetting> forKey(GlobalSettingKey key) {

--- a/data/src/main/java/hera/store/unit/GuildSettingAccessUnit.java
+++ b/data/src/main/java/hera/store/unit/GuildSettingAccessUnit.java
@@ -10,7 +10,7 @@ import java.util.List;
 public class GuildSettingAccessUnit extends StorageAccessUnit<GuildSetting>{
 
 	public GuildSettingAccessUnit() {
-		super(GuildSetting.class, GuildSetting.ENTITY_NAME);
+		super(GuildSetting.class);
 	}
 
 	public List<GuildSetting> forGuild(Long guild) {

--- a/data/src/main/java/hera/store/unit/LocalisationAccessUnit.java
+++ b/data/src/main/java/hera/store/unit/LocalisationAccessUnit.java
@@ -10,7 +10,7 @@ import java.util.List;
 public class LocalisationAccessUnit extends StorageAccessUnit<Localisation>{
 
 	public LocalisationAccessUnit() {
-		super(Localisation.class, Localisation.ENTITY_NAME);
+		super(Localisation.class);
 	}
 
 	public List<Localisation> forLanguage(String language) {

--- a/data/src/main/java/hera/store/unit/ModuleSettingsAccessUnit.java
+++ b/data/src/main/java/hera/store/unit/ModuleSettingsAccessUnit.java
@@ -13,7 +13,7 @@ public class ModuleSettingsAccessUnit extends StorageAccessUnit<ModuleSettings>{
 	private static final Logger LOG = LoggerFactory.getLogger(ModuleSettingsAccessUnit.class);
 
 	public ModuleSettingsAccessUnit() {
-		super(ModuleSettings.class, ModuleSettings.ENTITY_NAME);
+		super(ModuleSettings.class);
 	}
 
 	public List<ModuleSettings> forGuild(Long guild) {

--- a/data/src/main/java/hera/store/unit/RoleAccessUnit.java
+++ b/data/src/main/java/hera/store/unit/RoleAccessUnit.java
@@ -9,7 +9,7 @@ import java.util.List;
 public class RoleAccessUnit extends StorageAccessUnit<Role>{
 
 	public RoleAccessUnit() {
-		super(Role.class, Role.ENTITY_NAME);
+		super(Role.class);
 	}
 
 	public List<Role> forGuild(Long guild) {

--- a/data/src/main/java/hera/store/unit/RoleMemberAccessUnit.java
+++ b/data/src/main/java/hera/store/unit/RoleMemberAccessUnit.java
@@ -11,7 +11,7 @@ import java.util.List;
 public class RoleMemberAccessUnit extends StorageAccessUnit<RoleMember>{
 
 	public RoleMemberAccessUnit() {
-		super(RoleMember.class, RoleMember.ENTITY_NAME);
+		super(RoleMember.class);
 	}
 
 	public List<RoleMember> forRole(Role role) {

--- a/data/src/main/java/hera/store/unit/StorageAccessUnit.java
+++ b/data/src/main/java/hera/store/unit/StorageAccessUnit.java
@@ -12,18 +12,18 @@ import java.util.Map;
 public class StorageAccessUnit<T extends PersistenceEntity> {
 	private static final Logger LOG = LoggerFactory.getLogger(StorageAccessUnit.class);
 
-	DAO<T> dao;
+	protected DAO<T> dao;
 
-	private Class<T> cl;
+	protected Class<T> cl;
 
 	public StorageAccessUnit() {
 	}
 
-	public StorageAccessUnit(Class<T> cl, String entityName) {
-		dao = new DAO<>(cl, entityName);
+	public StorageAccessUnit(Class<T> cl) {
+		dao = new DAO<>(cl);
 		this.cl = cl;
 
-		LOG.info("StorageAccessUnit for entity {} created and initialized", cl.getName());
+		LOG.info("StorageAccessUnit for entity {} created and initialized", cl.getSimpleName());
 	}
 
 	public List<T> getAll() {
@@ -49,7 +49,7 @@ public class StorageAccessUnit<T extends PersistenceEntity> {
 
 			throw new FailedAfterRetriesException("DB modification failed after 3 retries");
 		} catch(FailedAfterRetriesException e) {
-			LOG.error("Error while trying to get entity of type {}", cl.getName());
+			LOG.error("Error while trying to get entity of type {}", cl.getSimpleName());
 			LOG.debug("Stacktrace:", e);
 		}
 
@@ -79,7 +79,7 @@ public class StorageAccessUnit<T extends PersistenceEntity> {
 
 			throw new FailedAfterRetriesException("DB modification failed after 3 retries");
 		} catch(FailedAfterRetriesException e) {
-			LOG.error("Error while trying to get entity of type {}", cl.getName());
+			LOG.error("Error while trying to get entity of type {}", cl.getSimpleName());
 			LOG.debug("Stacktrace:", e);
 		}
 
@@ -109,7 +109,7 @@ public class StorageAccessUnit<T extends PersistenceEntity> {
 
 			throw new FailedAfterRetriesException("DB modification failed after 3 retries");
 		} catch(FailedAfterRetriesException e) {
-			LOG.error("Error while trying to get entity of type {}", cl.getName());
+			LOG.error("Error while trying to get entity of type {}", cl.getSimpleName());
 			LOG.debug("Stacktrace:", e);
 		}
 
@@ -120,7 +120,7 @@ public class StorageAccessUnit<T extends PersistenceEntity> {
 		try {
 			retryOnFail(() -> dao.insert(entity));
 		} catch(FailedAfterRetriesException e) {
-			LOG.error("Error while trying to add entity of type {}", cl.getName());
+			LOG.error("Error while trying to add entity of type {}", cl.getSimpleName());
 			LOG.debug("Stacktrace:", e);
 		}
 	}
@@ -129,7 +129,7 @@ public class StorageAccessUnit<T extends PersistenceEntity> {
 		try {
 			retryOnFail(() -> dao.delete(entity));
 		} catch(FailedAfterRetriesException e) {
-			LOG.error("Error while trying to delete entity of type {}", cl.getName());
+			LOG.error("Error while trying to delete entity of type {}", cl.getSimpleName());
 			LOG.debug("Stacktrace:", e);
 		}
 	}
@@ -138,7 +138,7 @@ public class StorageAccessUnit<T extends PersistenceEntity> {
 		try {
 			retryOnFail(() -> dao.delete(id));
 		} catch(FailedAfterRetriesException e) {
-			LOG.error("Error while trying to delete entity of type {}", cl.getName());
+			LOG.error("Error while trying to delete entity of type {}", cl.getSimpleName());
 			LOG.debug("Stacktrace:", e);
 		}
 	}
@@ -147,7 +147,7 @@ public class StorageAccessUnit<T extends PersistenceEntity> {
 		try {
 			retryOnFail(() -> dao.update(entity));
 		} catch(FailedAfterRetriesException e) {
-			LOG.error("Error while trying to update entity of type {}", cl.getName());
+			LOG.error("Error while trying to update entity of type {}", cl.getSimpleName());
 			LOG.debug("Stacktrace:", e);
 		}
 	}
@@ -156,7 +156,7 @@ public class StorageAccessUnit<T extends PersistenceEntity> {
 		try {
 			retryOnFail(() -> dao.upsert(entity));
 		} catch(FailedAfterRetriesException e) {
-			LOG.error("Error while trying to upsert entity of type {}", cl.getName());
+			LOG.error("Error while trying to upsert entity of type {}", cl.getSimpleName());
 			LOG.debug("Stacktrace:", e);
 		}
 	}
@@ -181,6 +181,6 @@ public class StorageAccessUnit<T extends PersistenceEntity> {
 			}
 		}
 
-		throw new FailedAfterRetriesException("DB modification failed after 3 retries");
+		throw new FailedAfterRetriesException("-----> DB modification failed after 3 retries <-----");
 	}
 }

--- a/data/src/main/java/hera/store/unit/TokenAccessUnit.java
+++ b/data/src/main/java/hera/store/unit/TokenAccessUnit.java
@@ -11,7 +11,7 @@ import java.util.List;
 public class TokenAccessUnit extends StorageAccessUnit<Token>{
 
 	public TokenAccessUnit() {
-		super(Token.class, Token.ENTITY_NAME);
+		super(Token.class);
 	}
 	private static final Logger LOG = LoggerFactory.getLogger(GuildSettingAccessUnit.class);
 


### PR DESCRIPTION
The ENTITY_NAME constant in the db entities has become redundant because we pass in a class object to the DAO since the data module rewrite. This means that we can just call `class::getSimpleName` and get the same information.